### PR TITLE
Add sftp as subsystem to sshd

### DIFF
--- a/Infra/roles/users/templates/etc/ssh/sshd_config
+++ b/Infra/roles/users/templates/etc/ssh/sshd_config
@@ -18,3 +18,6 @@ AllowGroups remote_access
 
 # path to the banner 
 Banner {% if banner is defined %} /etc/ssh/sshd_banner {% else %} no {%endif%}
+
+# override default of no subsystems
+Subsystem   sftp    internal-sftp


### PR DESCRIPTION
That should resolve this warning message:
```
[WARNING]: sftp transfer mechanism failed on [drzwi]. Use ANSIBLE_DEBUG=1 to see detailed
information
``` 