### PR TITLE
Fix remove-logs.sh (shebang, word splitting)

### DIFF
--- a/Skrypty/remove-logs.sh
+++ b/Skrypty/remove-logs.sh
@@ -1,3 +1,3 @@
-#! /bin/bash
+#!/bin/bash
 
-sqlite3 ${DOOR_HOME}/doors.db < ${DOOR_HOME}/Kod/SQL/3-remove-logs.sql
+sqlite3 "${DOOR_HOME}/doors.db" < "${DOOR_HOME}/Kod/SQL/3-remove-logs.sql"


### PR DESCRIPTION
Nie wiem, czy teraz robi to, co powinno, ale poprawiłem najbardziej oczywiste błędy.